### PR TITLE
Implement login route

### DIFF
--- a/flasco/api/auth.py
+++ b/flasco/api/auth.py
@@ -1,9 +1,13 @@
 from http import HTTPStatus
 from fastapi import APIRouter, Depends, File, Query, Request, UploadFile
 
-from flasco.application.dtos.auth_dto import ProfessorDTO
-from flasco.dependencies import create_professor_user_usecase
+from flasco.application.dtos.auth_dto import LoginDTO, ProfessorDTO
+from flasco.dependencies import (
+    create_professor_user_usecase,
+    login_usecase,
+)
 from flasco.usecases.auth.create_user_professor import CreateUserProfessorUseCase
+from flasco.usecases.auth.login import LoginUseCase
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 
@@ -16,3 +20,11 @@ async def create_usuario_professor(
 ): 
     response = await create_user_usecase.execute(professor_data)
     return response
+
+
+@router.post("/login")
+async def login(
+    login_data: LoginDTO,
+    usecase: LoginUseCase = Depends(login_usecase),
+):
+    return await usecase.execute(login_data)

--- a/flasco/dependencies.py
+++ b/flasco/dependencies.py
@@ -2,8 +2,10 @@ from fastapi import Depends
 from flasco.database.filestorage import SupabaseStorage
 from flasco.database.database import get_async_session
 from flasco.repositories.professor_repository import UserRepository
+from flasco.repositories.usuario_repository import UsuarioRepository
 from flasco.repositories.video_repository import VideoRepository
 from flasco.usecases.auth.create_user_professor import CreateUserProfessorUseCase
+from flasco.usecases.auth.login import LoginUseCase
 from flasco.usecases.video_delete_usecase import DeleteVideoUseCase
 from flasco.usecases.video_get import GetVideoUseCase
 from flasco.usecases.video_list import VideoListUseCase
@@ -25,13 +27,24 @@ def get_video_repository(
 
 def user_repository(
     session: AsyncSession = Depends(get_async_session),
-) -> UserRepository: 
+) -> UserRepository:
     return  UserRepository(db_session=session)
+
+def usuario_repository(
+    session: AsyncSession = Depends(get_async_session),
+) -> UsuarioRepository:
+    return UsuarioRepository(db_session=session)
 
 def create_professor_user_usecase(
     user_repository: UserRepository = Depends(user_repository),
 ) -> CreateUserProfessorUseCase:
     return CreateUserProfessorUseCase(user_repository=user_repository)
+
+
+def login_usecase(
+    user_repository: UsuarioRepository = Depends(usuario_repository),
+) -> LoginUseCase:
+    return LoginUseCase(user_repository=user_repository)
 
 
 def video_upload_usecase(

--- a/flasco/main.py
+++ b/flasco/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from flasco.api.video import router as video_router
+from flasco.api.auth import router as auth_router
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 
 app.include_router(video_router)
+app.include_router(auth_router)
 
 origins = [
     "http://localhost:3000/",

--- a/flasco/repositories/usuario_repository.py
+++ b/flasco/repositories/usuario_repository.py
@@ -1,0 +1,14 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from flasco.models.usuario import Usuario
+
+
+class UsuarioRepository:
+    def __init__(self, db_session: AsyncSession):
+        self.db_session = db_session
+
+    async def get_by_email(self, email: str) -> Usuario | None:
+        query = select(Usuario).where(Usuario.email == email)
+        result = await self.db_session.execute(query)
+        return result.scalars().first()

--- a/flasco/usecases/auth/login.py
+++ b/flasco/usecases/auth/login.py
@@ -1,4 +1,23 @@
 from fastapi import HTTPException, status
+
 from flasco.application.dtos.auth_dto import LoginDTO
 from flasco.application.utils.auth import verify_password
-from flasco.infra
+from flasco.infra.services.jwt_token_service import create_access_token
+from flasco.repositories.usuario_repository import UsuarioRepository
+
+
+class LoginUseCase:
+    def __init__(self, user_repository: UsuarioRepository):
+        self.user_repository = user_repository
+
+    async def execute(self, login_data: LoginDTO):
+        user = await self.user_repository.get_by_email(login_data.email)
+        if not user or not verify_password(login_data.password, user.senha):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Email ou senha inválidos",
+            )
+        access_token = create_access_token(
+            {"user_id": str(user.id_usuario), "email": user.email}
+        )
+        return {"access_token": access_token, "token_type": "bearer"}


### PR DESCRIPTION
## Summary
- add repository to fetch user by email
- implement login usecase
- provide dependency providers for login
- expose `/auth/login` route and register it
- wire router in main app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6dae7b3483279151ba16063e6161